### PR TITLE
Move JS to header

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Add Ruby version to Gemfile
+- Moved JavaScript partial from inside <body> to inside <head> in application.html.erb
 
 ## V1.2 - Black Copper - 2015-10-31
 

--- a/templates/_javascript.html.erb
+++ b/templates/_javascript.html.erb
@@ -1,5 +1,3 @@
-<%= javascript_include_tag :application %>
-
 <%= yield :javascript %>
 
 <%= render "mixpanel" %>

--- a/templates/startblock_layout.html.erb.erb
+++ b/templates/startblock_layout.html.erb.erb
@@ -6,11 +6,13 @@
   <meta name="viewport" content="initial-scale=1" />
   <title>appname</title>
   <%%= stylesheet_link_tag :application, media: "all" %>
+  <%%= javascript_include_tag :application %>
+
+  <%%= render "javascript" %>
   <%%= csrf_meta_tags %>
 </head>
 <body>
   <%%= render "flashes" -%>
   <%%= yield %>
-  <%%= render "javascript" %>
 </body>
 </html>


### PR DESCRIPTION
This is a fix for https://github.com/firmhouse/Startblock/issues/44. I've chosen to just move the partial inside head, but I also extracted the regular javascript include line to make the application.html.erb look more like the Rails default file.

Fixes https://github.com/firmhouse/Startblock/issues/44
