### PR TITLE
Added bootstrap_form gem

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Added font-awesome-sass gem for including FontAwesome icons
+- Added bootstrap_form gem that includes a bootstrap form builder
 
 ### Changed
 - Add Ruby version to Gemfile

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -15,6 +15,7 @@ gem "redis", "~> 3.1.0"
 gem "redis-namespace", "~> 1.5.1"
 gem "nprogress-rails", "~> 0.1.6"
 gem "font-awesome-sass", "~> 4.5.0"
+gem "bootstrap_form", "~> 2.3.0"
 
 group :development do
   gem "spring"

--- a/templates/application.scss
+++ b/templates/application.scss
@@ -6,3 +6,4 @@
 @import "nprogress-bootstrap";
 @import "font-awesome-sprockets";
 @import "font-awesome-sass";
+@import "rails_bootstrap_forms";

--- a/test/features/new_project_test.rb
+++ b/test/features/new_project_test.rb
@@ -30,6 +30,7 @@ class NewProjectTest < Minitest::Test
     assert gemfile.match(/quiet_assets/), "Gemfile should contain quiet assets gem"
     assert gemfile.match(/nprogress-rails/), "Gemfile should contain NProgress-rails"
     assert gemfile.match(/font-awesome-sass/), "Gemfile should contain font-awesome-sass"
+    assert gemfile.match(/bootstrap_form/), "Gemfile should contain bootstrap_form"
   end
 
   def test_gemfile_should_contain_ruby_version
@@ -59,6 +60,7 @@ class NewProjectTest < Minitest::Test
     assert app_css_file.match(/bootstrap/), "Bootstrap should be present"
     assert app_css_file.match(/nprogress/), "Nprogress should be present"
     assert app_css_file.match(/font-awesome/), "FontAwesome should be present"
+    assert app_css_file.match(/rails_bootstrap_forms/), "Bootstrap Forms should be present"
   end
 
   def test_develoment_rb_content


### PR DESCRIPTION
This PR adds the Bootstrap Forms gem for Rails. This adds a helper `bootstrap_form_for` that uses a special Bootstrap form builder to style + build the form fields.

Fixes https://github.com/firmhouse/Startblock/issues/40
