### PR TITLE
Fix gemspec by only including Rails as runtime_dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,6 @@ PLATFORMS
 
 DEPENDENCIES
   minitest (~> 5.8)
-  rails (~> 4.2)
   rake
   startblock!
 

--- a/startblock.gemspec
+++ b/startblock.gemspec
@@ -27,7 +27,6 @@ start on a working app.
   s.version = Startblock::VERSION
 
   s.add_development_dependency "minitest", "~> 5.8"
-  s.add_development_dependency 'rails', Startblock::RAILS_VERSION
   s.add_runtime_dependency 'bundler', '~> 1.3'
   s.add_runtime_dependency 'rails', Startblock::RAILS_VERSION
   s.add_runtime_dependency 'thor', '~> 0.19'


### PR DESCRIPTION
Getting this error when trying to build the gem:

```
MacBook-Pro-van-Michiel:Startblock michiel$ gem build startblock.gemspec 
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    duplicate dependency on rails (~> 4.2), (~> 4.2) use:
    add_runtime_dependency 'rails', '~> 4.2', '~> 4.2'
```
