### PR TITLE
Don't raise on missing i18n

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Added
 ### Removed
+- Raise on missing I18n
+
 ### Fixed
 
 ## V1.4 - Maroon Lead - 2016-01-29

--- a/lib/startblock/app_builder.rb
+++ b/lib/startblock/app_builder.rb
@@ -43,11 +43,6 @@ module Startblock
       run "chmod a+x bin/setup"
     end
 
-    def configure_i18n_for_missing_translations
-      raise_on_missing_translations_in("development")
-      raise_on_missing_translations_in("test")
-    end
-
     def configuring_test_helper
       remove_file "test/test_helper.rb"
       template "test_helper.erb", "test/test_helper.rb"
@@ -137,14 +132,6 @@ end
 
     def setup_rubocop
       copy_file "rubocop.yml", ".rubocop.yml"
-    end
-
-    private
-
-    def raise_on_missing_translations_in(environment)
-      config = 'config.action_view.raise_on_missing_translations = true'
-
-      uncomment_lines("config/environments/#{environment}.rb", config)
     end
   end
 end

--- a/lib/startblock/generators/app_generator.rb
+++ b/lib/startblock/generators/app_generator.rb
@@ -48,7 +48,6 @@ module Startblock
       build :raise_on_delivery_errors
       build :raise_on_unpermitted_parameters
       build :provide_setup_script
-      build :configure_i18n_for_missing_translations
     end
 
     def setup_testing_environment


### PR DESCRIPTION
When we raise on missing i18n the logs are not shown to the browser anymore,
this is probably because it is also missing those translations.

This is not a problem if you develop english only apps, but if you do any other
language, this is causing massive issues and hard to track down bugs

/cc @michiels
